### PR TITLE
Fixed Form Files Encoding.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Bahmni Forms OpenMRS Module
+This module is responsible for manipulating Bahmni forms and their translations.
+
+## Building command
+### Build and Testing
+```
+mvn package -P deploy-web -D deploy.path="../../openmrs-1.8.x/webapp/src/main/webapp"
+```
+
+### Build and Skip Testing
+```
+mvn package -P deploy-web -D deploy.path="../../openmrs-1.8.x/webapp/src/main/webapp" -Dmaven.test.skip=true
+```

--- a/omod/src/main/java/org/openmrs/module/bahmni/ie/apps/service/impl/BahmniFormTranslationServiceImpl.java
+++ b/omod/src/main/java/org/openmrs/module/bahmni/ie/apps/service/impl/BahmniFormTranslationServiceImpl.java
@@ -124,7 +124,7 @@ public class BahmniFormTranslationServiceImpl extends BaseOpenmrsService impleme
 
     private void saveTranslationsToFile(JSONObject translationsJson, File translationFile) {
         try {
-            FileUtils.writeStringToFile(translationFile, translationsJson.toString());
+            FileUtils.writeStringToFile(translationFile, translationsJson.toString(), "UTF-8");
         } catch (IOException e) {
             e.printStackTrace();
             throw new APIException(e.getMessage(), e);
@@ -173,7 +173,7 @@ public class BahmniFormTranslationServiceImpl extends BaseOpenmrsService impleme
     private JSONObject getTranslations(File translationFile) {
         String fileContent;
         try {
-            fileContent = translationFile.exists() ? FileUtils.readFileToString(translationFile) : "";
+            fileContent = translationFile.exists() ? FileUtils.readFileToString(translationFile, "UTF-8") : "";
         } catch (IOException e) {
             e.printStackTrace();
             throw new APIException(e.getMessage(), e);


### PR DESCRIPTION
Form file are now saved in UTF-8 encoding and read using the same encoding. This allows for seamless Arabic integration and fixes the duplicate translation keys error.